### PR TITLE
Renamed configuration option

### DIFF
--- a/docs/features/media-embed.md
+++ b/docs/features/media-embed.md
@@ -55,7 +55,7 @@ ClassicEditor
 
 ### Data output format
 
-The data output format of the feature can be configured using the {@link module:media-embed/mediaembed~MediaEmbedConfig#mediaPreviewsInData `config.mediaEmbed.mediaPreviewsInData`} option.
+The data output format of the feature can be configured using the {@link module:media-embed/mediaembed~MediaEmbedConfig#previewsInData `config.mediaEmbed.previewsInData`} option.
 
 <info-box info>
 	This option does not change how media are displayed inside the editor – the previewable ones will still be displayed with previews. It only affects the output data (see below).
@@ -73,7 +73,7 @@ By default, the media embed feature outputs semantic `<oembed>` tags for preview
 
 #### Including previews in data
 
-Optionally, by setting `mediaEmbed.mediaPreviewsInData` to `true` you can configure the media embed feature to output media in the same way they look in the editor, this is, if this media is "previewable", the media preview (HTML) is saved to the database:
+Optionally, by setting `mediaEmbed.previewsInData` to `true` you can configure the media embed feature to output media in the same way they look in the editor, this is, if this media is "previewable", the media preview (HTML) is saved to the database:
 
 ```html
 <figure class="media">

--- a/src/mediaembed.js
+++ b/src/mediaembed.js
@@ -100,7 +100,7 @@ export default class MediaEmbed extends Plugin {
  * preview of a media identified by a certain id or a hash. When not defined, the media embed feature
  * will use a generic media representation in the view and output data.
  * Note that when
- * {@link module:media-embed/mediaembed~MediaEmbedConfig#mediaPreviewsInData `config.mediaEmbed.mediaPreviewsInData`}
+ * {@link module:media-embed/mediaembed~MediaEmbedConfig#previewsInData `config.mediaEmbed.previewsInData`}
  * is `true`, the rendering function **will always** be used for the media in the editor data output.
  */
 
@@ -154,7 +154,7 @@ export default class MediaEmbed extends Plugin {
  * only the most common are included.
  *
  * **Note**: Media without are always represented in the data using the "semantic" markup. See
- * {@link module:media-embed/mediaembed~MediaEmbedConfig#mediaPreviewsInData `config.mediaEmbed.mediaPreviewsInData`} to
+ * {@link module:media-embed/mediaembed~MediaEmbedConfig#previewsInData `config.mediaEmbed.previewsInData`} to
  * learn more about possible data outputs.
  *
  * **Note:**: The priority of media providers corresponds to the order of configuration. The first provider
@@ -251,9 +251,9 @@ export default class MediaEmbed extends Plugin {
  *		</figure>
  *
  * **Note:** Preview–less media are always represented in the data using the "semantic" markup
- * regardless of the value of the `mediaPreviewsInData`. Learn more about different kinds of media
+ * regardless of the value of the `previewsInData`. Learn more about different kinds of media
  * in the {@link module:media-embed/mediaembed~MediaEmbedConfig#providers `config.mediaEmbed.providers`}
  * configuration description.
  *
- * @member {Boolean} [module:media-embed/mediaembed~MediaEmbedConfig#mediaPreviewsInData=false]
+ * @member {Boolean} [module:media-embed/mediaembed~MediaEmbedConfig#previewsInData=false]
  */

--- a/src/mediaembedediting.js
+++ b/src/mediaembedediting.js
@@ -156,7 +156,7 @@ export default class MediaEmbedEditing extends Plugin {
 		const schema = editor.model.schema;
 		const t = editor.t;
 		const conversion = editor.conversion;
-		const renderMediaPreview = editor.config.get( 'mediaEmbed.mediaPreviewsInData' );
+		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
 		const registry = this.registry;
 
 		editor.commands.add( 'mediaEmbed', new MediaEmbedCommand( editor ) );

--- a/tests/manual/mediaembed.html
+++ b/tests/manual/mediaembed.html
@@ -2,6 +2,10 @@
 	input {
 		width: 500px;
 	}
+
+	body {
+		width: 700px;
+	}
 </style>
 
 <h2>Example URLs</h2>

--- a/tests/manual/mediaembed.js
+++ b/tests/manual/mediaembed.js
@@ -16,7 +16,7 @@ ClassicEditor
 			'heading', '|', 'mediaEmbed', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'
 		],
 		mediaEmbed: {
-			mediaPreviewsInData: true
+			previewsInData: true
 		}
 	} )
 	.then( editor => {

--- a/tests/manual/semanticmediaembed.html
+++ b/tests/manual/semanticmediaembed.html
@@ -2,6 +2,10 @@
 	input {
 		width: 500px;
 	}
+
+	body {
+		width: 700px;
+	}
 </style>
 
 <h2>Example URLs</h2>

--- a/tests/mediaembedediting.js
+++ b/tests/mediaembedediting.js
@@ -473,7 +473,7 @@ describe( 'MediaEmbedEditing', () => {
 		} );
 
 		describe( 'conversion in the data pipeline', () => {
-			describe( 'mediaPreviewsInData=false', () => {
+			describe( 'previewsInData=false', () => {
 				beforeEach( () => {
 					return createTestEditor( {
 						providers: providerDefinitions
@@ -618,11 +618,11 @@ describe( 'MediaEmbedEditing', () => {
 				} );
 			} );
 
-			describe( 'mediaPreviewsInData=true', () => {
+			describe( 'previewsInData=true', () => {
 				beforeEach( () => {
 					return createTestEditor( {
 						providers: providerDefinitions,
-						mediaPreviewsInData: true
+						previewsInData: true
 					} )
 						.then( newEditor => {
 							editor = newEditor;
@@ -791,7 +791,7 @@ describe( 'MediaEmbedEditing', () => {
 		} );
 
 		describe( 'conversion in the editing pipeline', () => {
-			describe( 'mediaPreviewsInData=false', () => {
+			describe( 'previewsInData=false', () => {
 				beforeEach( () => {
 					return createTestEditor( {
 						providers: providerDefinitions
@@ -807,11 +807,11 @@ describe( 'MediaEmbedEditing', () => {
 				test();
 			} );
 
-			describe( 'mediaPreviewsInData=true', () => {
+			describe( 'previewsInData=true', () => {
 				beforeEach( () => {
 					return createTestEditor( {
 						providers: providerDefinitions,
-						mediaPreviewsInData: true
+						previewsInData: true
 					} )
 						.then( newEditor => {
 							editor = newEditor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Renamed a key in configuration object: `mediaEmbed.mediaPreviewsInData` => `mediaEmbed.previewsInData`. Closes #38.
