### PR TITLE
Added missing contexts for translations

### DIFF
--- a/lang/contexts.json
+++ b/lang/contexts.json
@@ -1,0 +1,6 @@
+{
+	"Media URL": "Label for the URL input in the Media Embed URL editing balloon.",
+	"The URL must not be empty.": "An error message that informs about an empty value in the URL input.",
+	"This media URL is not supported.": "An error message that informs about not supported media.",
+	"Insert media": "Toolbar button tooltip for the Media Embed feature."
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Added missing `lang/contexts.json` file for translation service. Closes #40.
