### PR TITLE
Pasting a URL when a media element is selected will replace the URL for the media

### DIFF
--- a/src/automediaembed.js
+++ b/src/automediaembed.js
@@ -119,11 +119,9 @@ export default class AutoMediaEmbed extends Plugin {
 		let url = '';
 
 		for ( const node of walker ) {
-			if ( !node.item.is( 'textProxy' ) ) {
-				continue;
+			if ( node.item.is( 'textProxy' ) ) {
+				url += node.item.data;
 			}
-
-			url += node.item.data;
 		}
 
 		url = url.trim();

--- a/src/automediaembed.js
+++ b/src/automediaembed.js
@@ -119,6 +119,10 @@ export default class AutoMediaEmbed extends Plugin {
 		let url = '';
 
 		for ( const node of walker ) {
+			if ( !node.item.is( 'textProxy' ) ) {
+				continue;
+			}
+
 			url += node.item.data;
 		}
 

--- a/tests/automediaembed.js
+++ b/tests/automediaembed.js
@@ -302,6 +302,21 @@ describe( 'AutoMediaEmbed - integration', () => {
 			);
 		} );
 
+		it( 'replaces a URL in media if pasted a link when other media element was selected', () => {
+			setData(
+				editor.model,
+				'[<media url="https://open.spotify.com/album/2IXlgvecaDqOeF3viUZnPI?si=ogVw7KlcQAGZKK4Jz9QzvA"></media>]'
+			);
+
+			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
+
+			clock.tick( 100 );
+
+			expect( getData( editor.model ) ).to.equal(
+				'[<media url="https://www.youtube.com/watch?v=H08tGjXNHO4"></media>]'
+			);
+		} );
+
 		it( 'does nothing if URL match to media but it was removed', () => {
 			return ClassicTestEditor
 				.create( editorElement, {

--- a/tests/automediaembed.js
+++ b/tests/automediaembed.js
@@ -317,6 +317,25 @@ describe( 'AutoMediaEmbed - integration', () => {
 			);
 		} );
 
+		it( 'inserts a new media element if pasted a link when other media element was selected in correct place', () => {
+			setData(
+				editor.model,
+				'<paragraph>Foo. <$text linkHref="https://cksource.com">Bar</$text></paragraph>' +
+				'[<media url="https://open.spotify.com/album/2IXlgvecaDqOeF3viUZnPI?si=ogVw7KlcQAGZKK4Jz9QzvA"></media>]' +
+				'<paragraph><$text bold="true">Bar</$text>.</paragraph>'
+			);
+
+			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
+
+			clock.tick( 100 );
+
+			expect( getData( editor.model ) ).to.equal(
+				'<paragraph>Foo. <$text linkHref="https://cksource.com">Bar</$text></paragraph>' +
+				'[<media url="https://www.youtube.com/watch?v=H08tGjXNHO4"></media>]' +
+				'<paragraph><$text bold="true">Bar</$text>.</paragraph>'
+			);
+		} );
+
 		it( 'does nothing if URL match to media but it was removed', () => {
 			return ClassicTestEditor
 				.create( editorElement, {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pasting a URL when a media element is selected will replace the URL for the media. Closes #51.

---

### Additional information

Because #51 is assigned to next iteration, this PR will be able to merge after release.
