### PR TITLE
AutoMediaEmbed checks whether the media can be inserted

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ckeditor/ckeditor5-clipboard": "^10.0.3",
     "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-enter": "^10.1.2",
+    "@ckeditor/ckeditor5-image": "^11.0.0",
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-utils": "^11.0.0",
     "@ckeditor/ckeditor5-undo": "^10.0.3",

--- a/src/automediaembed.js
+++ b/src/automediaembed.js
@@ -136,6 +136,13 @@ export default class AutoMediaEmbed extends Plugin {
 			return;
 		}
 
+		const mediaEmbedCommand = editor.commands.get( 'mediaEmbed' );
+
+		// Do not anything if media element cannot be inserted at the current position.
+		if ( !mediaEmbedCommand.isEnabled ) {
+			return;
+		}
+
 		// Position won't be available in the `setTimeout` function so let's clone it.
 		this._positionToInsert = LivePosition.createFromPosition( leftPosition );
 
@@ -151,7 +158,7 @@ export default class AutoMediaEmbed extends Plugin {
 					writer.setSelection( this._positionToInsert );
 				}
 
-				editor.commands.execute( 'mediaEmbed', url );
+				mediaEmbedCommand.execute( url );
 
 				this._positionToInsert.detach();
 				this._positionToInsert = null;

--- a/tests/automediaembed.js
+++ b/tests/automediaembed.js
@@ -17,6 +17,8 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
 import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
@@ -29,7 +31,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ MediaEmbed, AutoMediaEmbed, Link, List, Bold, Typing ]
+				plugins: [ MediaEmbed, AutoMediaEmbed, Link, List, Bold, Typing, Image, ImageCaption ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -299,6 +301,17 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			expect( getData( editor.model ) ).to.equal(
 				'<paragraph>youtube.com/watch?v=H08tGjXNHO4&param=foo bar[]</paragraph>'
+			);
+		} );
+
+		it( 'does not transform a valid URL into a media if the element cannot be placed in the current position', () => {
+			setData( editor.model, '<image src="foo.png"><caption>Foo.[]</caption></image>' );
+			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
+
+			clock.tick( 100 );
+
+			expect( getData( editor.model ) ).to.equal(
+				'<image src="foo.png"><caption>Foo.https://www.youtube.com/watch?v=H08tGjXNHO4[]</caption></image>'
 			);
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `AutoMediaEmbed` will not handle a pasted URL if a media element cannot be inserted at the current position. Closes #47.
