### PR TITLE
t/53: Floated content and media widgets should not overlap

### DIFF
--- a/src/mediaembed.js
+++ b/src/mediaembed.js
@@ -13,6 +13,8 @@ import MediaEmbedUI from './mediaembedui';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
+import '../theme/mediaembed.css';
+
 /**
  * The media embed plugin.
  *

--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+.ck-content .media {
+	/* Don't allow floated content overlap the media.
+	https://github.com/ckeditor/ckeditor5-media-embed/issues/53 */
+	clear: both;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Floated content and media widgets should not overlap. Closes #53.

---

### Additional information

I'm not sure whether this is a content style provided by a feature or a snippet style in our docs. I'd say the former but who knows ;-)
