### PR TITLE
t/58: Made the media interactive when the editor is in the read–only mode

### DIFF
--- a/theme/mediaembedediting.css
+++ b/theme/mediaembedediting.css
@@ -6,10 +6,6 @@
 @import "@ckeditor/ckeditor5-ui/theme/components/tooltip/mixins/_tooltip.css";
 
 .ck-media__wrapper {
-	& > *:not(.ck-media__placeholder) {
-		pointer-events: none;
-	}
-
 	& .ck-media__placeholder {
 		display: flex;
 		flex-direction: column;
@@ -42,4 +38,10 @@
 			display: none;
 		}
 	}
+}
+
+/* Disable all mouse interaction as long as the editor is not read–only.
+   https://github.com/ckeditor/ckeditor5-media-embed/issues/58 */
+*[contenteditable=true] .ck-media__wrapper > *:not(.ck-media__placeholder) {
+	pointer-events: none;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Made the media interactive when the editor is in the read–only mode (just like links). Closes #58.

---

**Note:** The only drawback of this solution is that e.g. when a user switches to the read–only mode and plays a video in the media and then the editor goes back to the editing mode, the video will keep playing without any possibility to stop it. In theory, it could be a serious UX issue. 

There's no way we can "stop the media". The only solution would be to re-render them in the view each time switching back to `editor.isReadOnly = false` so the content of the iframes is refreshed and they go back to the default, passive state.