### PR TITLE
t/theme-lark/209:  Moved widget spacing styles from Lark to the feature content styles sheet

### DIFF
--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -7,4 +7,7 @@
 	/* Don't allow floated content overlap the media.
 	https://github.com/ckeditor/ckeditor5-media-embed/issues/53 */
 	clear: both;
+
+	/* Make sure there is some space between the content and the media. */
+	margin: 1em 0;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Moved widget spacing styles from ckeditor5-theme-lark to the feature content styles sheet (see ckeditor/ckeditor5-theme-lark#209).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5-theme-lark/pull/210.
