### PR TITLE
Media embed should be always displayed with display: block.

### DIFF
--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -11,7 +11,7 @@
 	/* Make sure there is some space between the content and the media. */
 	margin: 1em 0;
 
-	/* Make sure media is displayed properly (overwrite Bootstrap default styles).
+	/* Make sure media is not overriden with Bootstrap default `flex` value.
 	See: https://github.com/ckeditor/ckeditor5/issues/1373. */
 	display: block;
 }

--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -10,4 +10,8 @@
 
 	/* Make sure there is some space between the content and the media. */
 	margin: 1em 0;
+
+	/* Make sure media is displayed properly (overwrite Bootstrap default styles).
+	See: https://github.com/ckeditor/ckeditor5/issues/1373. */
+	display: block;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Default display of media embed should be `display: block`. Closes https://github.com/ckeditor/ckeditor5/issues/1373.