### PR TITLE
t/ckeditor5/1520: Got rid of the symbol used to recognise view elements

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,10 +9,9 @@
 
 import { isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 
-const mediaSymbol = Symbol( 'isMedia' );
-
 /**
  * Converts a given {@link module:engine/view/element~Element} to a media embed widget:
+ *
  * * Adds a {@link module:engine/view/element~Element#_setCustomProperty custom property} allowing to recognize the media widget element.
  * * Calls the {@link module:widget/utils~toWidget} function with the proper element's label creator.
  *
@@ -22,8 +21,6 @@ const mediaSymbol = Symbol( 'isMedia' );
  * @returns {module:engine/view/element~Element}
  */
 export function toMediaWidget( viewElement, writer, label ) {
-	writer.setCustomProperty( mediaSymbol, true, viewElement );
-
 	return toWidget( viewElement, writer, { label } );
 }
 
@@ -50,7 +47,7 @@ export function getSelectedMediaViewWidget( selection ) {
  * @returns {Boolean}
  */
 export function isMediaWidget( viewElement ) {
-	return !!viewElement.getCustomProperty( mediaSymbol ) && isWidget( viewElement );
+	return isWidget( viewElement ) && viewElement.hasClass( 'media' );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the symbol used to recognize view elements (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1521
