### PR TITLE
t/ckeditor5/1520b: Got rid of the Symbols used to recognize view elements; replaced with strings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -9,8 +9,6 @@
 
 import { isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 
-const mediaSymbol = Symbol( 'isMedia' );
-
 /**
  * Converts a given {@link module:engine/view/element~Element} to a media embed widget:
  * * Adds a {@link module:engine/view/element~Element#_setCustomProperty custom property} allowing to recognize the media widget element.
@@ -22,7 +20,7 @@ const mediaSymbol = Symbol( 'isMedia' );
  * @returns {module:engine/view/element~Element}
  */
 export function toMediaWidget( viewElement, writer, label ) {
-	writer.setCustomProperty( mediaSymbol, true, viewElement );
+	writer.setCustomProperty( 'media', true, viewElement );
 
 	return toWidget( viewElement, writer, { label } );
 }
@@ -50,7 +48,7 @@ export function getSelectedMediaViewWidget( selection ) {
  * @returns {Boolean}
  */
 export function isMediaWidget( viewElement ) {
-	return !!viewElement.getCustomProperty( mediaSymbol ) && isWidget( viewElement );
+	return !!viewElement.getCustomProperty( 'media' ) && isWidget( viewElement );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Got rid of the Symbols used to recognize view elements; replaced with strings (see ckeditor/ckeditor5#1520).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1532 constellation.
