### PR TITLE
Prevent of opening links for not selected media placeholders

### DIFF
--- a/src/mediaregistry.js
+++ b/src/mediaregistry.js
@@ -298,7 +298,8 @@ class Media {
 					tag: 'a',
 					attributes: {
 						class: 'ck-media__placeholder__url',
-						target: 'new',
+						target: '_blank',
+						rel: 'noopener noreferrer',
 						href: this.url
 					},
 					children: [

--- a/tests/mediaembedediting.js
+++ b/tests/mediaembedediting.js
@@ -927,7 +927,7 @@ describe( 'MediaEmbedEditing', () => {
 						'<div[^>]+>' +
 							'<div class="ck ck-media__placeholder ck-reset_all">' +
 								'<div class="ck-media__placeholder__icon">.*</div>' +
-								`<a class="ck-media__placeholder__url" href="${ expectedUrl }" target="new">` +
+								`<a class="ck-media__placeholder__url" href="${ expectedUrl }" rel="noopener noreferrer" target="_blank">` +
 									`<span class="ck-media__placeholder__url__text">${ expectedUrl }</span>` +
 									'<span class="ck ck-tooltip ck-tooltip_s">' +
 										'<span class="ck ck-tooltip__text">Open media in new tab</span>' +

--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -19,7 +19,3 @@
 	from being "squashed" in tight spaces, e.g. in table cells (#44) */
 	min-width: 15em;
 }
-
-.ck-editor__editable:not( .ck-read-only ) .ck-widget:not( .ck-widget_selected ) .ck-media__placeholder {
-	pointer-events: none;
-}

--- a/theme/mediaembed.css
+++ b/theme/mediaembed.css
@@ -19,3 +19,7 @@
 	from being "squashed" in tight spaces, e.g. in table cells (#44) */
 	min-width: 15em;
 }
+
+.ck-editor__editable:not( .ck-read-only ) .ck-widget:not( .ck-widget_selected ) .ck-media__placeholder {
+	pointer-events: none;
+}

--- a/theme/mediaembedediting.css
+++ b/theme/mediaembedediting.css
@@ -45,3 +45,9 @@
 .ck-editor__editable:not(.ck-read-only) .ck-media__wrapper > *:not(.ck-media__placeholder) {
 	pointer-events: none;
 }
+
+/* Disable all mouse interaction when the widget is not selected (e.g. to avoid opening links by accident).
+   https://github.com/ckeditor/ckeditor5-media-embed/issues/18 */
+.ck-editor__editable:not(.ck-read-only) .ck-widget:not(.ck-widget_selected) .ck-media__placeholder {
+	pointer-events: none;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent of opening links for not selected media placeholders. Closes #18.

---

### Additional information
* I additionally correct target attribute of opened link.