### PR TITLE
Added support for preview of Facebook video #6105

### DIFF
--- a/src/mediaembedediting.js
+++ b/src/mediaembedediting.js
@@ -139,6 +139,23 @@ export default class MediaEmbedEditing extends Plugin {
 					url: /^flickr\.com/
 				},
 				{
+					name: 'facebook-video',
+					url: [
+						/(https:\/\/www\.facebook\.com\/([\S]*)\/videos\/([0-9]*))/gm,
+						/(https:\/\/www\.facebook\.com\/watch\/\?v\=([0-9]*))/gm
+					],
+					html: match => {
+						return (
+							'<div style="position: relative; padding-bottom: 100%; height: 0; ">' +
+								`<iframe src="https://www.facebook.com/plugins/video.php?show_text=false&href=`+ encodeURI(match[0]) +`" ` +
+									'style="position: absolute; width: 100%; height: 100%; top: 0; left: 0;" ' +
+									'frameborder="0" width="480" height="270" allowfullscreen allow="autoplay">' +
+								'</iframe>' +
+							'</div>'
+						);
+					}
+				},
+				{
 					name: 'facebook',
 					url: /^facebook\.com/
 				},


### PR DESCRIPTION
## 📝 Provide a description of the improvement

_Now links like https://www.facebook.com/realitetiofficial/videos/458353101779653/ or https://www.facebook.com/watch/?v=458353101779653 will have preview._

TODO (can't do this myself)
- [ ] Fix portrait videos shrink.

## 📃 Details

* Browser: not applicable
* OS: not applicable
* CKEditor version: not applicable
* Installed CKEditor plugins: MediaEmbed v16.0.0
---

If you'd like to see this improvement implemented, add a 👍 reaction to this post.
