### PR TITLE
i/6553: Replace .ck-labeled-input class with .ck-labeled-field-view

### DIFF
--- a/theme/mediaform.css
+++ b/theme/mediaform.css
@@ -11,7 +11,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 
-	& .ck-labeled-input {
+	& .ck-labeled-field-view {
 		display: inline-block;
 	}
 
@@ -22,7 +22,7 @@
 	@mixin ck-media-phone {
 		flex-wrap: wrap;
 
-		& .ck-labeled-input {
+		& .ck-labeled-field-view {
 			flex-basis: 100%;
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Replaced `.ck-labeled-input` class with `.ck-labeled-field-view`. See ckeditor/ckeditor5#6553.

⚠️**Required:** 
- [ ] ckeditor/ckeditor5-ui#553

---

### Additional information

These changes fix missing styles after merging ckeditor/ckeditor5/issues/6110. 
