### PR TITLE
Create MediaFormView for each dropdown instance separately.

### DIFF
--- a/src/mediaembedui.js
+++ b/src/mediaembedui.js
@@ -41,19 +41,15 @@ export default class MediaEmbedUI extends Plugin {
 		const command = editor.commands.get( 'mediaEmbed' );
 		const registry = editor.plugins.get( MediaEmbedEditing ).registry;
 
-		/**
-		 * The form view displayed inside the drop-down.
-		 *
-		 * @member {module:media-embed/ui/mediaformview~MediaFormView}
-		 */
-		this.form = new MediaFormView( getFormValidators( editor.t, registry ), editor.locale );
-
 		// Setup `imageUpload` button.
 		editor.ui.componentFactory.add( 'mediaEmbed', locale => {
 			const dropdown = createDropdown( locale );
 
-			this._setUpDropdown( dropdown, this.form, command, editor );
-			this._setUpForm( this.form, dropdown, command );
+			// Prepare custom view for dropdown's panel.
+			const mediaForm = new MediaFormView( getFormValidators( editor.t, registry ), editor.locale );
+
+			this._setUpDropdown( dropdown, mediaForm, command, editor );
+			this._setUpForm( mediaForm, dropdown, command );
 
 			return dropdown;
 		} );

--- a/src/mediaembedui.js
+++ b/src/mediaembedui.js
@@ -45,11 +45,10 @@ export default class MediaEmbedUI extends Plugin {
 		editor.ui.componentFactory.add( 'mediaEmbed', locale => {
 			const dropdown = createDropdown( locale );
 
-			// Prepare custom view for dropdown's panel.
 			const mediaForm = new MediaFormView( getFormValidators( editor.t, registry ), editor.locale );
 
 			this._setUpDropdown( dropdown, mediaForm, command, editor );
-			this._setUpForm( mediaForm, dropdown, command );
+			this._setUpForm( dropdown, mediaForm, command );
 
 			return dropdown;
 		} );
@@ -99,7 +98,7 @@ export default class MediaEmbedUI extends Plugin {
 		}
 	}
 
-	_setUpForm( form, dropdown, command ) {
+	_setUpForm( dropdown, form, command ) {
 		form.delegate( 'submit', 'cancel' ).to( dropdown );
 		form.urlInputView.bind( 'value' ).to( command, 'value' );
 

--- a/tests/mediaembedui.js
+++ b/tests/mediaembedui.js
@@ -54,9 +54,12 @@ describe( 'MediaEmbedUI', () => {
 	} );
 
 	it( 'should allow creating two instances', () => {
+		let secondInstance;
+
 		expect( function createSecondInstance() {
-			editor.ui.componentFactory.create( 'mediaEmbed' );
+			secondInstance = editor.ui.componentFactory.create( 'mediaEmbed' );
 		} ).not.to.throw();
+		expect( dropdown ).to.be.not.equal( secondInstance );
 	} );
 
 	describe( 'dropdown', () => {

--- a/tests/mediaembedui.js
+++ b/tests/mediaembedui.js
@@ -53,6 +53,12 @@ describe( 'MediaEmbedUI', () => {
 		expect( dropdown ).to.be.instanceOf( DropdownView );
 	} );
 
+	it( 'should allow creating two instances', () => {
+		expect( function createSecondInstance() {
+			editor.ui.componentFactory.create( 'mediaEmbed' );
+		} ).not.to.throw();
+	} );
+
 	describe( 'dropdown', () => {
 		it( 'should bind #isEnabled to the command', () => {
 			const command = editor.commands.get( 'mediaEmbed' );

--- a/tests/mediaembedui.js
+++ b/tests/mediaembedui.js
@@ -59,7 +59,7 @@ describe( 'MediaEmbedUI', () => {
 		expect( function createSecondInstance() {
 			secondInstance = editor.ui.componentFactory.create( 'mediaEmbed' );
 		} ).not.to.throw();
-		expect( dropdown ).to.be.not.equal( secondInstance );
+		expect( dropdown ).to.not.equal( secondInstance );
 	} );
 
 	describe( 'dropdown', () => {


### PR DESCRIPTION
Fixes ckeditor/ckeditor5#6333

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Create MediaFormView for each dropdown instance separately. Closes ckeditor/ckeditor5#6333

MINOR BREAKING CHANGE: `mediaembedui~MediaEmbedUI#form` was removed from the API

---

### Additional information

Previously it was trying to attach the same `MediaFormView` instance form for all dropdowns instances, then attach actions multiple times.

BTW, I was thinking about refactoring a bit `_setUpDropdown` and `_setUpForm`, to have the same order of arguments, but decided to keep the changes to the minimum.